### PR TITLE
Configure default TLS config with root CAs

### DIFF
--- a/drone/resource_orgsecret.go
+++ b/drone/resource_orgsecret.go
@@ -33,7 +33,7 @@ func resourceOrgSecret() *schema.Resource {
 				ForceNew: false,
 			},
 			"allow_push_on_pull_request": {
-				Type:     schema.TypeString,
+				Type:     schema.TypeBool,
 				Optional: true,
 				ForceNew: false,
 			},

--- a/drone/resource_orgsecret_test.go
+++ b/drone/resource_orgsecret_test.go
@@ -11,8 +11,8 @@ import (
 
 func TestOrgSecret(t *testing.T) {
 	resource.Test(t, resource.TestCase{
-		PreCheck: func() { testAccPreCheck(t) },
-		Providers: testProviders,
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testProviders,
 		CheckDestroy: testOrgSecretDestroy,
 		Steps: []resource.TestStep{
 			{
@@ -66,7 +66,7 @@ func testOrgSecretDestroy(state *terraform.State) error {
 
 		err := client.OrgSecretDelete(namespace, name)
 		if err == nil {
-			return fmt.Errorf("namespace Secret still exists: %s/%s", namespace, name)
+			return fmt.Errorf("namespace OrgSecret still exists: %s/%s", namespace, name)
 		}
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/Lucretius/terraform-provider-drone
 go 1.12
 
 require (
+	github.com/jackspirou/syscerts v0.0.0-20160531025014-b68f5469dff1
 	github.com/drone/drone-go v1.3.0
 	github.com/hashicorp/terraform v0.12.7
 	golang.org/x/oauth2 v0.0.0-20190319182350-c85d3e98c914

--- a/go.sum
+++ b/go.sum
@@ -264,6 +264,8 @@ github.com/hashicorp/yamux v0.0.0-20160720233140-d1caa6c97c9f/go.mod h1:+NfK9FKe
 github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb h1:b5rjCoWHc7eqmAS4/qyk21ZsHyb6Mxv/jykxvNTkU4M=
 github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
+github.com/jackspirou/syscerts v0.0.0-20160531025014-b68f5469dff1 h1:9Xm8CKtMZIXgcopfdWk/qZ1rt0HjMgfMR9nxxSeK6vk=
+github.com/jackspirou/syscerts v0.0.0-20160531025014-b68f5469dff1/go.mod h1:zuHl3Hh+e9P6gmBPvcqR1HjkaWHC/csgyskg6IaFKFo=
 github.com/jellevandenhooff/dkim v0.0.0-20150330215556-f50fe3d243e1/go.mod h1:E0B/fFc00Y+Rasa88328GlI/XbtyysCtTHZS8h7IrBU=
 github.com/jen20/awspolicyequivalence v0.0.0-20170831201602-3d48364a137a/go.mod h1:uoIMjNxUfXi48Ci40IXkPRbghZ1vbti6v9LCbNqRgHY=
 github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=


### PR DESCRIPTION
Getting some weird transport socket errors when using the provider from Terraform Cloud. Since our server RPC is exposed publicly on HTTPS using LetsEncrypt certificates, the kind of error seen makes me think about the need to configure the TLS communication using the OS root CAs.

The code in here is mostly taken from the actual implementation of the Drone CLI, which is able to communicate with the server from Terraform Cloud.