### PR TITLE
More informative error messages

### DIFF
--- a/drone/resource_cron.go
+++ b/drone/resource_cron.go
@@ -99,7 +99,7 @@ func resourceCronRead(data *schema.ResourceData, meta interface{}) error {
 	cronName := data.Get("name").(string)
 	cron, err := client.Cron(owner, repo, cronName)
 	if err != nil {
-		return fmt.Errorf("[ERROR] Failed to read Drone Cron: %s/%s/%s", owner, repo, cronName)
+		return fmt.Errorf("failed to read Drone Cron: %s/%s/%s", owner, repo, cronName)
 	}
 
 	return readCron(data, cron, owner, repo, err)
@@ -142,10 +142,10 @@ func resourceCronExists(data *schema.ResourceData, meta interface{}) (bool, erro
 	cronName := data.Get("name").(string)
 	cron, err := client.Cron(owner, repo, cronName)
 	if err != nil {
-		return false, fmt.Errorf("[ERROR] Failed to read Drone Cron: %s/%s/%s", owner, repo, cronName)
+		return false, fmt.Errorf("failed to read Drone Cron: %s/%s/%s", owner, repo, cronName)
 	}
 
-	exists := (cron.Name == cronName) && (err == nil)
+	exists := cron.Name == cronName
 	return exists, err
 }
 

--- a/drone/resource_cron.go
+++ b/drone/resource_cron.go
@@ -98,6 +98,9 @@ func resourceCronRead(data *schema.ResourceData, meta interface{}) error {
 	}
 	cronName := data.Get("name").(string)
 	cron, err := client.Cron(owner, repo, cronName)
+	if err != nil {
+		return fmt.Errorf("[ERROR] Failed to read Drone Cron: %s/%s/%s", owner, repo, cronName)
+	}
 
 	return readCron(data, cron, owner, repo, err)
 }
@@ -138,6 +141,9 @@ func resourceCronExists(data *schema.ResourceData, meta interface{}) (bool, erro
 	}
 	cronName := data.Get("name").(string)
 	cron, err := client.Cron(owner, repo, cronName)
+	if err != nil {
+		return false, fmt.Errorf("[ERROR] Failed to read Drone Cron: %s/%s/%s", owner, repo, cronName)
+	}
 
 	exists := (cron.Name == cronName) && (err == nil)
 	return exists, err

--- a/drone/resource_orgsecret.go
+++ b/drone/resource_orgsecret.go
@@ -73,7 +73,7 @@ func resourceOrgSecretRead(data *schema.ResourceData, meta interface{}) error {
 
 	secret, err := client.OrgSecret(namespace, name)
 	if err != nil {
-		return fmt.Errorf("[ERROR] Failed to read Drone Org Secret: %s/%s", namespace, name)
+		return fmt.Errorf("failed to read Drone Org Secret: %s/%s", namespace, name)
 	}
 
 	readOrgSecret(data, namespace, secret)
@@ -119,7 +119,7 @@ func resourceOrgSecretExists(data *schema.ResourceData, meta interface{}) (bool,
 
 	secret, err := client.OrgSecret(namespace, name)
 	if err != nil {
-		return false, fmt.Errorf("[ERROR] Failed to read Drone Org Secret: %s/%s", namespace, name)
+		return false, fmt.Errorf("failed to read Drone Org Secret: %s/%s", namespace, name)
 	}
 
 	exists := (secret.Name == name) && (err == nil)

--- a/drone/resource_orgsecret.go
+++ b/drone/resource_orgsecret.go
@@ -2,7 +2,6 @@ package drone
 
 import (
 	"fmt"
-
 	"github.com/Lucretius/terraform-provider-drone/drone/utils"
 	"github.com/drone/drone-go/drone"
 	"github.com/hashicorp/terraform/helper/schema"
@@ -74,7 +73,7 @@ func resourceOrgSecretRead(data *schema.ResourceData, meta interface{}) error {
 
 	secret, err := client.OrgSecret(namespace, name)
 	if err != nil {
-		return err
+		return fmt.Errorf("[ERROR] Failed to read Drone Org Secret: %s/%s", namespace, name)
 	}
 
 	readOrgSecret(data, namespace, secret)
@@ -120,7 +119,7 @@ func resourceOrgSecretExists(data *schema.ResourceData, meta interface{}) (bool,
 
 	secret, err := client.OrgSecret(namespace, name)
 	if err != nil {
-		return false, err
+		return false, fmt.Errorf("[ERROR] Failed to read Drone Org Secret: %s/%s", namespace, name)
 	}
 
 	exists := (secret.Name == name) && (err == nil)

--- a/drone/resource_repo.go
+++ b/drone/resource_repo.go
@@ -105,7 +105,7 @@ func resourceRepoRead(data *schema.ResourceData, meta interface{}) error {
 
 	repository, err := client.Repo(owner, repo)
 	if err != nil {
-		return fmt.Errorf("[ERROR] Failed to read Drone Repo: %s/%s", owner, repo)
+		return fmt.Errorf("failed to read Drone Repo: %s/%s", owner, repo)
 	}
 
 	return readRepo(data, repository, err)
@@ -148,7 +148,7 @@ func resourceRepoExists(data *schema.ResourceData, meta interface{}) (bool, erro
 
 	repository, err := client.Repo(owner, repo)
 	if err != nil {
-		return false, fmt.Errorf("[ERROR] Failed to read Drone Repo: %s/%s", owner, repo)
+		return false, fmt.Errorf("failed to read Drone Repo: %s/%s", owner, repo)
 	}
 
 	exists := (repository.Namespace == owner) && (repository.Name == repo)

--- a/drone/resource_repo.go
+++ b/drone/resource_repo.go
@@ -104,6 +104,9 @@ func resourceRepoRead(data *schema.ResourceData, meta interface{}) error {
 	}
 
 	repository, err := client.Repo(owner, repo)
+	if err != nil {
+		return fmt.Errorf("[ERROR] Failed to read Drone Repo: %s/%s", owner, repo)
+	}
 
 	return readRepo(data, repository, err)
 }
@@ -144,8 +147,11 @@ func resourceRepoExists(data *schema.ResourceData, meta interface{}) (bool, erro
 	}
 
 	repository, err := client.Repo(owner, repo)
+	if err != nil {
+		return false, fmt.Errorf("[ERROR] Failed to read Drone Repo: %s/%s", owner, repo)
+	}
 
-	exists := (repository.Namespace == owner) && (repository.Name == repo) && (err == nil)
+	exists := (repository.Namespace == owner) && (repository.Name == repo)
 
 	return exists, err
 }

--- a/drone/resource_secret.go
+++ b/drone/resource_secret.go
@@ -77,6 +77,9 @@ func resourceSecretRead(data *schema.ResourceData, meta interface{}) error {
 	}
 
 	secret, err := client.Secret(owner, repo, name)
+	if err != nil {
+		return fmt.Errorf("[ERROR] Failed to read Drone Secret: %s/%s/%s", owner, repo, name)
+	}
 
 	return readSecret(data, owner, repo, secret, err)
 }
@@ -119,8 +122,11 @@ func resourceSecretExists(data *schema.ResourceData, meta interface{}) (bool, er
 	}
 
 	secret, err := client.Secret(owner, repo, name)
+	if err != nil {
+		return false, fmt.Errorf("[ERROR] Failed to read Drone Secret: %s/%s/%s", owner, repo, name)
+	}
 
-	exists := (secret.Name == name) && (err == nil)
+	exists := secret.Name == name
 
 	return exists, err
 }

--- a/drone/resource_secret.go
+++ b/drone/resource_secret.go
@@ -78,7 +78,7 @@ func resourceSecretRead(data *schema.ResourceData, meta interface{}) error {
 
 	secret, err := client.Secret(owner, repo, name)
 	if err != nil {
-		return fmt.Errorf("[ERROR] Failed to read Drone Secret: %s/%s/%s", owner, repo, name)
+		return fmt.Errorf("failed to read Drone Secret: %s/%s/%s", owner, repo, name)
 	}
 
 	return readSecret(data, owner, repo, secret, err)
@@ -123,7 +123,7 @@ func resourceSecretExists(data *schema.ResourceData, meta interface{}) (bool, er
 
 	secret, err := client.Secret(owner, repo, name)
 	if err != nil {
-		return false, fmt.Errorf("[ERROR] Failed to read Drone Secret: %s/%s/%s", owner, repo, name)
+		return false, fmt.Errorf("failed to read Drone Secret: %s/%s/%s", owner, repo, name)
 	}
 
 	exists := secret.Name == name

--- a/drone/resource_user.go
+++ b/drone/resource_user.go
@@ -2,7 +2,6 @@ package drone
 
 import (
 	"fmt"
-
 	"github.com/Lucretius/terraform-provider-drone/drone/utils"
 	"github.com/drone/drone-go/drone"
 	"github.com/hashicorp/terraform/helper/schema"
@@ -77,9 +76,8 @@ func resourceUserRead(data *schema.ResourceData, meta interface{}) error {
 	client := meta.(drone.Client)
 
 	user, err := client.User(data.Id())
-
 	if err != nil {
-		return fmt.Errorf("Unable to read user %s: %v", user.Login, err)
+		return fmt.Errorf("[ERROR] Failed to read Drone user with id: %s", data.Id())
 	}
 
 	return readUser(data, user, err)
@@ -97,8 +95,11 @@ func resourceUserExists(data *schema.ResourceData, meta interface{}) (bool, erro
 	login := data.Id()
 
 	user, err := client.User(login)
+	if err != nil {
+		return false, fmt.Errorf("[ERROR] Failed to read Drone user with id: %s", data.Id())
+	}
 
-	exists := (user.Login == login) && (err == nil)
+	exists := user.Login == login
 
 	return exists, err
 }

--- a/drone/resource_user.go
+++ b/drone/resource_user.go
@@ -77,7 +77,7 @@ func resourceUserRead(data *schema.ResourceData, meta interface{}) error {
 
 	user, err := client.User(data.Id())
 	if err != nil {
-		return fmt.Errorf("[ERROR] Failed to read Drone user with id: %s", data.Id())
+		return fmt.Errorf("failed to read Drone user with id: %s", data.Id())
 	}
 
 	return readUser(data, user, err)
@@ -96,7 +96,7 @@ func resourceUserExists(data *schema.ResourceData, meta interface{}) (bool, erro
 
 	user, err := client.User(login)
 	if err != nil {
-		return false, fmt.Errorf("[ERROR] Failed to read Drone user with id: %s", data.Id())
+		return false, fmt.Errorf("failed to read Drone user with id: %s", data.Id())
 	}
 
 	exists := user.Login == login


### PR DESCRIPTION
This changes error messages from: `Error: client error 404: {"message":"Not Found"}` to `Error: [ERROR] Failed to read Drone Repo: orgname/repo-name`